### PR TITLE
Bump main to next pre-release after stable release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,7 +60,9 @@ jobs:
           MAJOR=$(echo "$VERSION" | cut -d . -f 1)
           MINOR=$(echo "$VERSION" | cut -d . -f 2)
           PATCH=$(echo "$VERSION" | cut -d . -f 3)
-          PATCH=$((PATCH + 1))  # Increment the patch version for pre-release
+          if [[ "${{ steps.trigger.outputs.triggered_by }}" == "tag" ]]; then
+            PATCH=$((PATCH + 1))
+          fi
           DATETIME=$(date +%Y%m%d.%H%M%S)  # Use timestamp for uniqueness
           NEW_VERSION="$MAJOR.$MINOR.$PATCH-pre.$DATETIME"
           echo "version=$NEW_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 env:
   PYTHON_VERSION: '3.10'  # Set your desired Python version here
@@ -32,9 +33,25 @@ jobs:
           pip install build
           pip install .
 
-      - name: Get latest tag
+      - name: Determine trigger type
+        id: trigger
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            echo "triggered_by=tag" >> $GITHUB_OUTPUT
+          else
+            echo "triggered_by=branch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get latest tag from history
+        if: steps.trigger.outputs.triggered_by == 'branch'
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Get latest tag from pushed tag
+        if: steps.trigger.outputs.triggered_by == 'tag'
+        run: |
+          LATEST_TAG=${GITHUB_REF:11}
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
 
       - name: Calculate pre-release version
@@ -63,7 +80,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag v${{ env.version }}
+          git fetch origin main
+          MAIN_SHA=$(git rev-parse origin/main)
+          git tag v${{ env.version }} $MAIN_SHA
           git push origin v${{ env.version }}
 
       - name: Create GitHub pre-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create GitHub Release
+name: Release
 on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
@@ -51,6 +51,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: v${{ env.version }}
+          generate_release_notes: true
           files: dist/*
           name: Release ${{ env.version }}
           body: |


### PR DESCRIPTION
This PR addresses the criteria from **A1** for **Versioning & Releases**"
- After a stable release, main is set to a pre-release version that is higher than the latest release.

Addresses issue: https://github.com/remla25-team6/operation/issues/1